### PR TITLE
feat: add Google Analytics tracking script to layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -21,6 +21,19 @@ const { title } = Astro.props
 
     <title>{title}</title>
 
+    <!-- Google tag (gtag.js) -->
+    <script async src='https://www.googletagmanager.com/gtag/js?id=G-SLVHKL1Z3Z'
+    ></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+
+      gtag('config', 'G-SLVHKL1Z3Z')
+    </script>
+
     <!-- Script para prevenir destello del dark mode -->
     <script is:inline>
       ;(function () {


### PR DESCRIPTION
This pull request adds Google Analytics tracking to the site by including the necessary Google Tag Manager scripts in the `Layout.astro` file.

Analytics integration:

* Added the Google Analytics (gtag.js) script and initialization code to the HTML head in `src/layouts/Layout.astro` to enable site usage tracking.